### PR TITLE
fix: Persist editor state across changes

### DIFF
--- a/src/Editor/index.js
+++ b/src/Editor/index.js
@@ -1,84 +1,68 @@
-import React,{useState,useEffect} from 'react';
-import { EditorState, convertFromRaw, convertToRaw, conver } from 'draft-js';
-//import draftToHtml from 'draftjs-to-html';
-import { stateToHTML } from 'draft-js-export-html';
-import { initiateSocket, disconnectSocket, subscribeToChat, sendMessage } from './socketService';
-import { Editor } from 'react-draft-wysiwyg';
-import 'react-draft-wysiwyg/dist/react-draft-wysiwyg.css';
-import { Typography } from '@mui/material';
-import {toolbarOptions } from './const'
+import React, { useState, useEffect } from "react";
+import { EditorState, convertFromRaw, convertToRaw } from "draft-js";
+import {
+  initiateSocket,
+  disconnectSocket,
+  subscribeToChat,
+  sendMessage
+} from "./socketService";
+import { Editor } from "react-draft-wysiwyg";
+import "react-draft-wysiwyg/dist/react-draft-wysiwyg.css";
+import { Typography } from "@mui/material";
 
 export default function MyEditor() {
- const [editorState, setEditorState] = React.useState(() => EditorState.createEmpty());
-const[selectionState,setSelectionState]=useState(null)
+  const [editorState, setEditorState] = React.useState(() =>
+    EditorState.createEmpty()
+  );
+  const [room] = useState("Test");
 
- const [room,setRoom]=useState('Test')
- useEffect(()=>{
- EditorState.moveSelectionToEnd(editorState);
- },[editorState])
- useEffect(() => {
-  if (room) initiateSocket(room);
-  
-  subscribeToChat((err, data) => {
-  console.log("=====>",data);
-    if (err) return;
-   if(data){
-       const item=convertFromRaw(JSON.parse(data))
-       console.log(item)
-       const getState =EditorState.createWithContent(item);
-    setEditorState(getState) /*, ...oldChats*/
-   
+  useEffect(() => {
+    if (room) initiateSocket(room);
+    subscribeToChat((err, data) => {
+      if (err) return;
+      if (data) {
+        console.log("=====");
+        console.log(data);
+        const item = convertFromRaw(JSON.parse(data));
+        const getState = EditorState.createWithContent(item);
+        setEditorState(getState); /*, ...oldChats*/
+      }
+    });
+    return () => {
+      disconnectSocket();
+    };
+  }, [room]);
 
-   }
-
-  });
-  return () => {
-   disconnectSocket();
+  const changeState = (d) => {
+    sendMessage(room, JSON.stringify(convertToRaw(d.getCurrentContent())));
+    setEditorState(d);
   };
- }, [room]);
 
-const changeState=(d)=>{
-    
-    console.log(convertToRaw(d.getCurrentContent()));
-    sendMessage(room,JSON.stringify(convertToRaw(d.getCurrentContent())));
-
-}
-
-
- function myBlockRenderer(contentBlock) {
-  const type = contentBlock.getType();
-  if (type === 'header-one') {
-   return {
-    component: Typography,
-    editable: false,
-    props: {
-     variant: 'h1',
-    },
-   };
+  function myBlockRenderer(contentBlock) {
+    const type = contentBlock.getType();
+    if (type === "header-one") {
+      return {
+        component: Typography,
+        editable: false,
+        props: {
+          variant: "h1"
+        }
+      };
+    }
   }
- }
 
- let htmlOptions = {
-  blockRenderers: {
-   'header-one': (block) => {
-    return <Typography variant="h1">escape(block.getText()</Typography>;
-   },
-  },
- };
-
- return (
-  <>
-   <div>
-    <Editor
-    style={{border:'1px solid #ddd'}}
-     editorState={editorState}
-     onEditorStateChange={(state)=>changeState(state)}
-     wrapperClassName="demo-wrapper"
-     editorClassName="demo-editor"
-     // toolbar={toolbarOptions}
-     customBlockRenderFunc={myBlockRenderer}
-    />
-   </div>
-  </>
- );
+  return (
+    <>
+      <div>
+        <Editor
+          style={{ border: "1px solid #ddd" }}
+          editorState={editorState}
+          onEditorStateChange={(state) => changeState(state)}
+          wrapperClassName="demo-wrapper"
+          editorClassName="demo-editor"
+          customBlockRenderFunc={myBlockRenderer}
+        />
+      </div>
+    </>
+  );
 }

--- a/src/Editor/index.js
+++ b/src/Editor/index.js
@@ -1,5 +1,7 @@
 import React, { useState, useEffect } from "react";
-import { EditorState, convertFromRaw, convertToRaw } from "draft-js";
+import { EditorState, convertFromRaw, convertToRaw, conver } from "draft-js";
+//import draftToHtml from 'draftjs-to-html';
+import { stateToHTML } from "draft-js-export-html";
 import {
   initiateSocket,
   disconnectSocket,
@@ -14,16 +16,22 @@ export default function MyEditor() {
   const [editorState, setEditorState] = React.useState(() =>
     EditorState.createEmpty()
   );
+
   const [room] = useState("Test");
 
   useEffect(() => {
+    EditorState.moveSelectionToEnd(editorState);
+  }, [editorState]);
+
+  useEffect(() => {
     if (room) initiateSocket(room);
+
     subscribeToChat((err, data) => {
+      console.log("=====>", data);
       if (err) return;
       if (data) {
-        console.log("=====");
-        console.log(data);
         const item = convertFromRaw(JSON.parse(data));
+        console.log(item);
         const getState = EditorState.createWithContent(item);
         setEditorState(getState); /*, ...oldChats*/
       }
@@ -34,6 +42,7 @@ export default function MyEditor() {
   }, [room]);
 
   const changeState = (d) => {
+    console.log(convertToRaw(d.getCurrentContent()));
     sendMessage(room, JSON.stringify(convertToRaw(d.getCurrentContent())));
     setEditorState(d);
   };
@@ -51,6 +60,14 @@ export default function MyEditor() {
     }
   }
 
+  let htmlOptions = {
+    blockRenderers: {
+      "header-one": (block) => {
+        return <Typography variant="h1">escape(block.getText()</Typography>;
+      }
+    }
+  };
+
   return (
     <>
       <div>
@@ -60,6 +77,7 @@ export default function MyEditor() {
           onEditorStateChange={(state) => changeState(state)}
           wrapperClassName="demo-wrapper"
           editorClassName="demo-editor"
+          // toolbar={toolbarOptions}
           customBlockRenderFunc={myBlockRenderer}
         />
       </div>


### PR DESCRIPTION
The problem was basically that we didn't set the editor state across user changes. 

I've added two commits:
- One fixes the issue and removes unused code.
- One reverts unused code removal and only fixes the issue (incase you'd like to merge this).

You can view the editor working on this link:
https://codesandbox.io/s/crazy-sammet-zr7td?file=/src/Editor/index.js